### PR TITLE
Update template for latest azd 0.8.0

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
 
 name: pamelafox-site
-hooks:
-  predeploy:
-    run: ./src/deploy.sh
-    interactive: true
 services:
   web:
     project: ./src
     dist: flaskapp/build
     language: python
     host: staticwebapp
+    hooks:
+      prepackage:
+      run: ./deploy.sh
+      interactive: true


### PR DESCRIPTION
predeploy hook is a little useless after azd 0.8.0.

azd now creates an application package before provision. And during deploy, it uses the package previously created to publish. So, if the preprovision hook is doing something for the deployment, it will be useless,, as deploy will take what was packaged before