### PR TITLE
fix for swa-cli on ci build

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -6,5 +6,11 @@ python3 -m venv scripts/.venv
 echo 'Installing dependencies from "requirements.txt" into virtual environment'
 ./scripts/.venv/bin/python -m pip install -r requirements.txt
 
-echo 'Running "prepdocs.py"'
+echo 'Running "python freeze"'
 ./scripts/.venv/bin/python ./freeze.py
+
+# staticwebapp.config.json needs to be manually copyed because the swa-cli
+# fails when it tries to do this copy when running within a build pipeline (Github and Azdo).
+# See: https://github.com/Azure/static-web-apps-cli/issues/688
+echo 'copying swa settings'
+cp staticwebapp.config.json flaskapp/build/staticwebapp.config.json


### PR DESCRIPTION
Hey @pamelafox , I found the root cause for the swa-cli failing on CI build
See: https://github.com/Azure/static-web-apps-cli/issues/688

This workaround should fix it.

I'll follow up with swa-cli folks..  if they fix this, we would remove this workaround.  I am planning to also add this patch for our todo-swa templates