### PR TITLE
Use emojis for talk links

### DIFF
--- a/src/flaskapp/static/styles.css
+++ b/src/flaskapp/static/styles.css
@@ -105,8 +105,8 @@ ul {
   font-size: smaller;
 }
 
-.links img {
+.links .emoji-icon {
   vertical-align: middle;
-  width: 20px;
-  height: 20px;
+  display: inline-block;
+  margin-right: 2px;
 }

--- a/src/flaskapp/templates/index.html
+++ b/src/flaskapp/templates/index.html
@@ -6,7 +6,7 @@
 
   <div class="inner">
     <p>I am a human that likes to learn, teach, and create.</p>
-    <p>I am currently a Principal Cloud Advocate at Microsoft, focusing on the ways that developers can use Python with Azure services (Web Apps, Functions, etc).
+    <p>I am currently a Principal Cloud Advocate at Microsoft, focusing on the ways that developers can use Python with Azure, Foundry, GitHub, and VS Code.
     <p>In my past lives, I've...
     <ul>
      <li>Lectured at UC Berkeley, teaching <a href="https://inst.eecs.berkeley.edu/~cs61a/sp22/">CS61A</a>, <a href="https://cs302.org/sp22/">CS302</a>, and other CS classes.
@@ -25,20 +25,19 @@
     <p>Please know the following:</p>
     <ul>
       <li>My time is limited since I have two young kids and a full-time job. Alas, I  will need to say "No" to most requests of my time that aren't related to my family or work.
-      <li>In terms of conferences and meetups, I may be available for local events (bay area) or virtual events. I have more availability during the workday (when I have childcare) than evenings/weekends. I'm the most interested in events that relate to Python or Microsoft/Azure, given my current job.
+      <li>In terms of conferences and meetups, I may be available for local events (bay area) or virtual events. I have more availability during the workday (when I have childcare) than evenings/weekends.
     </ul>
     <p>If you're still keen on sending me a message after reading that, go for it! My gmail address is exactly what you'd expect it to be 😊.</p>
    </div>
 
   <div class="divider">where am I on the web?</div>
   <div class="inner">
-  <a href="https://fosstodon.org/@pamelafox">mastodon</a> -
   <a href="https://www.linkedin.com/in/pamela-s-fox/">linkedin</a> -
+  <a href="https://twitter.com/pamelafox">twitter</a> -
+  <a href="https://fosstodon.org/@pamelafox">mastodon</a> -
   <a href="https://bsky.app/profile/pamelafox.bsky.social">bluesky</a> -
   <a href="http://blog.pamelafox.org">blogger</a> -
-  <a href="http://github.com/pamelafox">github</a> -
-  <!-- <a href="http://twitter.com/pamelafox">twitter</a> - -->
-  <a href="http://medium.com/@pamelafox">medium</a> -
+  <a href="https://github.com/pamelafox">github</a> -
   <!-- <a href="https://www.khanacademy.org/profile/pamela/">khan academy</a> - -->
   <a href="https://www.thingiverse.com/pamelafox/designs">thingiverse</a>
   </div>

--- a/src/flaskapp/templates/talks.html
+++ b/src/flaskapp/templates/talks.html
@@ -15,9 +15,9 @@
    Given {{ talk.date }} at {{ talk.location }}.
    </div>
    <div class="links">
-  {% if talk.code %}<a href="{{ talk.code }}"><img src="/static/source_icon.png" alt="">View Code</a> {% endif %}
-   {% if talk.writeup %}<a href="{{ talk.writeup }}">Read Write-up</a> {% endif %}
-   {% if talk.video %}<a href="{{ talk.video }}"><img src="/static/video_icon.png" alt="">Watch Video</a> {% endif %}
+  {% if talk.code %}<a href="{{ talk.code }}"><span class="emoji-icon" aria-hidden="true">💻</span>View Code</a> {% endif %}
+   {% if talk.writeup %}<a href="{{ talk.writeup }}"><span class="emoji-icon" aria-hidden="true">📝</span>Read Write-up</a> {% endif %}
+   {% if talk.video %}<a href="{{ talk.video }}"><span class="emoji-icon" aria-hidden="true">🎥</span>Watch Video</a> {% endif %}
    </div>
   {% endfor %}
   </ul>


### PR DESCRIPTION
This updates the talks page link styling to use simple, consistent emojis instead of a mix of image icon formats. That keeps the talk links visually lighter while making code, write-up, and video links easier to distinguish at a glance.

## What changed
- replaces the talks page image icons with emoji markers for code, write-up, and video links
- updates the talks link styling to target the emoji spans instead of image tags
- drops the temporary SVG icon files in favor of a simpler text-based approach

## Notes
- this only affects the talks page link treatment; project source links still use the existing source icon