### PR TITLE
Add MCP workshop and Foundry IQ lab talks

### DIFF
--- a/src/flaskapp/data/talks.json
+++ b/src/flaskapp/data/talks.json
@@ -1,5 +1,18 @@
 [
   {
+    "title": "Using and building MCP servers with GitHub Copilot",
+    "date": "2026-06-18T05:00:00.000Z",
+    "description": "A 4-hour internal workshop at Microsoft covering how to use and build MCP servers. Participants connected GitHub Copilot (VS Code/CLI/App) to both public and authenticated MCP servers, built a basic server with Python and FastMCP, and finished up with MCP apps and elicitations.",
+    "thumbnail": null,
+    "slides": "https://pamelafox.github.io/github-copilot-mcp-tutorial/",
+    "code": "https://github.com/pamelafox/github-copilot-mcp-tutorial",
+    "video": null,
+    "tags": "python, mcp, github copilot",
+    "location": "Microsoft (internal)",
+    "cospeakers": null,
+    "include": "yes"
+  },
+  {
     "title": "An MCP for your Postgres DB",
     "date": "2026-06-16T20:50:47.000Z",
     "description": "An exploration of MCP server design for PostgreSQL databases using Python and FastMCP, comparing free-form SQL, read-only SQL, and fully typed tools, with elicitation and tool selection strategies for safer, more reliable database agents.",

--- a/src/flaskapp/data/talks.json
+++ b/src/flaskapp/data/talks.json
@@ -2,7 +2,7 @@
   {
     "title": "Using and building MCP servers with GitHub Copilot",
     "date": "2026-06-18T05:00:00.000Z",
-    "description": "A 4-hour internal workshop at Microsoft covering how to use and build MCP servers. Participants connected GitHub Copilot (VS Code/CLI/App) to both public and authenticated MCP servers, built a basic server with Python and FastMCP, and finished up with MCP apps and elicitations.",
+    "description": "A 2-hour workshop, with slides, covering how to use and build MCP servers. Participants connected GitHub Copilot (VS Code/CLI/App) to both public and authenticated MCP servers, built a basic server with Python and FastMCP, and finished up with MCP apps and elicitations.",
     "thumbnail": null,
     "slides": "https://pamelafox.github.io/github-copilot-mcp-tutorial/",
     "code": "https://github.com/pamelafox/github-copilot-mcp-tutorial",


### PR DESCRIPTION
Adds two new talks to talks.json:

- **From data to context: Agent-ready knowledge with Foundry IQ** — Hands-on lab at Microsoft Build 2026 (June 2) with Ayça Bas and Matt Gotteiner
- **Using and building MCP servers with GitHub Copilot** — Internal Microsoft workshop (June 18)